### PR TITLE
feat: implement server-side pagination for GET /avaliacoes

### DIFF
--- a/cpa-main/cpa-main/backend/src/controllers/avaliacoesController.ts
+++ b/cpa-main/cpa-main/backend/src/controllers/avaliacoesController.ts
@@ -15,8 +15,10 @@ const createAvaliacao = asyncHandler(async (req: Request, res: Response) => {
 });
 
 const getAvaliacoes = asyncHandler(async (req: Request, res: Response) => {
-    const avaliacoes = await avaliacoesService.getAll();
-    res.status(200).json(avaliacoes);
+    const page = Math.max(0, parseInt(req.query.page as string, 10) || 0);
+    const pageSize = Math.min(100, Math.max(1, parseInt(req.query.pageSize as string, 10) || 10));
+    const result = await avaliacoesService.getAllPaginated(page, pageSize);
+    res.status(200).json(result);
 });
 
 const getAvaliacoesDisponiveis = asyncHandler(async (req: Request, res: Response) => {

--- a/cpa-main/cpa-main/backend/src/repositories/avaliacaoRepository.ts
+++ b/cpa-main/cpa-main/backend/src/repositories/avaliacaoRepository.ts
@@ -39,6 +39,38 @@ const findMany = () => {
     });
 };
 
+const includeRelations = {
+    avaliacao_questoes: {
+        include: {
+            questoes: {
+                include: {
+                    questoes_adicionais: true,
+                    dimensoes: { include: { eixos: true } }
+                }
+            }
+        }
+    },
+    unidade: true,
+    categorias: true,
+    cursos: true,
+    modalidades: true,
+} as const;
+
+/**
+ * Busca avaliações paginadas com o total geral para server-side pagination
+ */
+const findManyPaginated = (skip: number, take: number): Promise<[any[], number]> => {
+    return Promise.all([
+        prisma.avaliacao.findMany({
+            skip,
+            take,
+            orderBy: { id: 'desc' },
+            include: includeRelations,
+        }),
+        prisma.avaliacao.count(),
+    ]);
+};
+
 /**
  * Busca uma avaliação pelo ID com relações completas
  */
@@ -237,6 +269,7 @@ export {
     create,
     encerrarVencidas,
     findMany,
+    findManyPaginated,
     findById,
     findByIdSimple,
     findDisponiveis,

--- a/cpa-main/cpa-main/backend/src/services/avaliacoesService.ts
+++ b/cpa-main/cpa-main/backend/src/services/avaliacoesService.ts
@@ -77,6 +77,24 @@ class AvaliacoesService {
         return avaliacoes.map((a: any) => this.mapAvaliacao(a));
     }
 
+    async getAllPaginated(page: number, limit: number): Promise<{
+        data: AvaliacaoResponseDTO[];
+        meta: { total: number; page: number; limit: number; totalPages: number };
+    }> {
+        await avaliacaoRepository.encerrarVencidas();
+        const skip = page * limit;
+        const [avaliacoes, total] = await avaliacaoRepository.findManyPaginated(skip, limit);
+        return {
+            data: avaliacoes.map((a: any) => this.mapAvaliacao(a)),
+            meta: {
+                total,
+                page,
+                limit,
+                totalPages: Math.ceil(total / limit),
+            },
+        };
+    }
+
     async getDisponiveis(cursoUsuario: string, matricula: string): Promise<AvaliacaoResponseDTO[]> {
         const avaliacoes = await avaliacaoRepository.findDisponiveis(cursoUsuario, new Date());
 

--- a/cpa-main/cpa-main/frontend/src/api/avaliacoes.js
+++ b/cpa-main/cpa-main/frontend/src/api/avaliacoes.js
@@ -1,6 +1,7 @@
 import api from './index';
 
-export const getAvaliacoes = () => api.get('/avaliacoes');
+export const getAvaliacoes = (page = 0, pageSize = 10) =>
+    api.get('/avaliacoes', { params: { page, pageSize } });
 export const getAvaliacoesDisponiveis = () => api.get('/avaliacoes/disponiveis');
 export const createAvaliacao = (avaliacaoData) => api.post('/avaliacoes', avaliacaoData);
 export const editarAvaliacao = (id, avaliacaoData) => api.put(`/avaliacoes/${id}`, avaliacaoData);

--- a/cpa-main/cpa-main/frontend/src/components/Tables/Table_Avaliacao.jsx
+++ b/cpa-main/cpa-main/frontend/src/components/Tables/Table_Avaliacao.jsx
@@ -49,7 +49,13 @@ const fmt = d => {
 };
 
 const Table_Avaliacao = ({ filtroStatus, searchQuery = '', onSuccess, onVerDetalhes, onEditar }) => {
-    const { data: avaliacoes = [], isLoading: loading, isError } = useGetAvaliacoesQuery();
+    const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
+
+    const { data: response, isLoading: loading, isError } = useGetAvaliacoesQuery(paginationModel);
+
+    const avaliacoes = response?.data ?? [];
+    const rowCount = response?.meta?.total ?? 0;
+
     const deleteMutation = useDeleteAvaliacaoMutation();
     const enviarMutation = useEnviarAvaliacaoMutation();
     const prorrogarMutation = useProrrogarAvaliacaoMutation();
@@ -320,10 +326,11 @@ const Table_Avaliacao = ({ filtroStatus, searchQuery = '', onSuccess, onVerDetal
                 rows={rows}
                 columns={columns}
                 loading={loading}
+                paginationMode="server"
+                rowCount={rowCount}
+                paginationModel={paginationModel}
+                onPaginationModelChange={setPaginationModel}
                 pageSizeOptions={[10, 25, 50]}
-                initialState={{
-                    pagination: { paginationModel: { pageSize: 10 } },
-                }}
                 density="compact"
                 disableRowSelectionOnClick
                 localeText={ptBR.components.MuiDataGrid.defaultProps.localeText}

--- a/cpa-main/cpa-main/frontend/src/hooks/queries/useAvaliacaoQueries.jsx
+++ b/cpa-main/cpa-main/frontend/src/hooks/queries/useAvaliacaoQueries.jsx
@@ -6,10 +6,10 @@ import {
     verificarSeUsuarioRespondeu
 } from '../../api/avaliacoes';
 
-export const useGetAvaliacoesQuery = () => {
+export const useGetAvaliacoesQuery = (paginationModel = { page: 0, pageSize: 10 }) => {
     return useQuery({
-        queryKey: ['avaliacoes'],
-        queryFn: getAvaliacoes,
+        queryKey: ['avaliacoes', paginationModel.page, paginationModel.pageSize],
+        queryFn: () => getAvaliacoes(paginationModel.page, paginationModel.pageSize),
     });
 };
 


### PR DESCRIPTION
- Repository: add findManyPaginated using Promise.all(findMany + count)
- Service: add getAllPaginated returning { data, meta: { total, page, limit, totalPages } }
- Controller: read page/pageSize query params, call getAllPaginated
- Frontend API: accept page and pageSize params in getAvaliacoes
- React Query hook: accept paginationModel, key by page+pageSize
- DataGrid: switch to paginationMode="server", bind rowCount and paginationModel

https://claude.ai/code/session_011zhbsTfeVqTFHmtv1XKA3S